### PR TITLE
Deploy disable action and optimize delete action

### DIFF
--- a/src/assets/helperFunctions/validationBranch.js
+++ b/src/assets/helperFunctions/validationBranch.js
@@ -1,3 +1,5 @@
+import { dbDateTimeToView } from "./index.js";
+
 const initBranchErrors = {
   brancherror: "",
   addresserror: "",
@@ -69,4 +71,40 @@ export const branchValidation = brn => {
     branch = Object.assign({}, { ...branch, ...errors });
   }
   return { isError, branch };
+};
+
+// Delete validation
+export const notDeletable = (allServiceshifts, selected) => {
+  let match = {};
+  let error = false;
+  let alert = "";
+  selected.forEach(id => {
+    allServiceshifts.map(serviceshift => {
+      let brnMatch = serviceshift.branch.id === id ? serviceshift : undefined;
+      if (brnMatch !== undefined) {
+        error = true;
+        let message = `Horario que inicia el ${
+          dbDateTimeToView(serviceshift.begindate).dateTime
+        } y finaliza el ${dbDateTimeToView(serviceshift.workspan).dateTime}\r\n`;
+        if (match[id] === undefined) {
+          match[serviceshift.branch.branch] = [message];
+        } else {
+          match[serviceshift.branch.branch].push(message);
+        }
+      }
+      return null;
+    });
+  });
+  let message = [];
+  Object.keys(match).forEach(key => {
+    message.push(`Sede ${key} asociada con:\r\n${match[key].map(m => `${m}`)}`);
+  });
+  if (error) {
+    alert = `No puede eliminar las siguientes sedes porque se encuentran asignadas a uno o varios horarios:\r\n${message.map(
+      m => `${m}`
+    )}`;
+  } else {
+    alert = `Sede(s) eliminada(s) correctamente`;
+  }
+  return { alert, error };
 };

--- a/src/assets/helperFunctions/validationBranch.js
+++ b/src/assets/helperFunctions/validationBranch.js
@@ -22,7 +22,7 @@ const lengthAttribute = object => {
   let isError = false;
   let errors = {};
   for (let attr in object) {
-    if (!attr.includes("error") && attr !== "id") {
+    if (!attr.includes("error") && attr !== "id" && attr !== "active") {
       if (!/\S/.test(object[attr])) {
         isError = true;
         errors[`${attr}error`] =
@@ -49,7 +49,7 @@ const lengthAttribute = object => {
           `${attr}error`
         ] = `El campo debe contener como mínimo 5 caracteres`;
       }
-      if (object[attr].length > 25) {
+      if (object[attr].length > 25 && attr !== "address") {
         isError = true;
         errors[
           `${attr}error`
@@ -85,8 +85,10 @@ export const notDeletable = (allServiceshifts, selected) => {
         error = true;
         let message = `Horario que inicia el ${
           dbDateTimeToView(serviceshift.begindate).dateTime
-        } y finaliza el ${dbDateTimeToView(serviceshift.workspan).dateTime}\r\n`;
-        if (match[id] === undefined) {
+        } y finaliza el ${
+          dbDateTimeToView(serviceshift.workspan).dateTime
+        }\r\n`;
+        if (match[serviceshift.branch.branch] === undefined) {
           match[serviceshift.branch.branch] = [message];
         } else {
           match[serviceshift.branch.branch].push(message);
@@ -105,6 +107,47 @@ export const notDeletable = (allServiceshifts, selected) => {
     )}`;
   } else {
     alert = `Sede(s) eliminada(s) correctamente`;
+  }
+  return { alert, error };
+};
+
+// Disable validation
+export const notDisable = (allServiceshifts, selected) => {
+  let match = {};
+  let error = false;
+  let alert = "";
+  const activeServiceshifts = allServiceshifts.filter(
+    serviceshift => serviceshift.active === true
+  );
+  selected.forEach(id => {
+    activeServiceshifts.map(serviceshift => {
+      let brnMatch = serviceshift.branch.id === id ? serviceshift : undefined;
+      if (brnMatch !== undefined) {
+        error = true;
+        let msgSsh = `Horario activo que inicia el ${
+          dbDateTimeToView(serviceshift.begindate).dateTime
+        } y finaliza el ${
+          dbDateTimeToView(serviceshift.workspan).dateTime
+        }\r\n`;
+        if (match[serviceshift.branch.branch] === undefined) {
+          match[serviceshift.branch.branch] = [msgSsh];
+        } else {
+          match[serviceshift.branch.branch].push(msgSsh);
+        }
+      }
+      return null;
+    });
+  });
+  let message = [];
+  Object.keys(match).forEach(key => {
+    message.push(`Sede ${key} asociado con:\r\n${match[key].map(m => `${m}`)}`);
+  });
+  if (error) {
+    alert = `No puede deshabilitar las siguientes sedes porque se encuentran asignadas a uno o varios horarios activos:\r\n${message.map(
+      m => `${m}`
+    )}`;
+  } else {
+    alert = `Estado de sede(s) ha sido cambiado exitosamente`;
   }
   return { alert, error };
 };

--- a/src/assets/helperFunctions/validationEmployee.js
+++ b/src/assets/helperFunctions/validationEmployee.js
@@ -14,7 +14,7 @@ const lengthAttribute = object => {
   let isError = false;
   let errors = {};
   for (let attr in object) {
-    if (!attr.includes("error") && attr !== "id") {
+    if (!attr.includes("error") && attr !== "id" && attr !== "active") {
       if (!/\S/.test(object[attr])) {
         isError = true;
         errors[`${attr}error`] =
@@ -86,6 +86,49 @@ export const notDeletable = (allServiceshifts, selected) => {
     )}`;
   } else {
     alert = `Empleados(s) eliminado(s) correctamente`;
+  }
+  return { alert, error };
+};
+
+// Disable validation
+export const notDisable = (allServiceshifts, selected) => {
+  let match = {};
+  let error = false;
+  let alert = "";
+  const activeServiceshifts = allServiceshifts.filter(
+    serviceshift => serviceshift.active === true
+  );
+  selected.forEach(user => {
+    activeServiceshifts.map(serviceshift => {
+      let empMatch = serviceshift.employees.find(emp => emp.user === user);
+      if (empMatch !== undefined) {
+        error = true;
+        let msgSsh = `Horario de sede ${
+          serviceshift.branch.branch
+        } con inicio el ${
+          dbDateTimeToView(serviceshift.begindate).dateTime
+        } y fin el ${dbDateTimeToView(serviceshift.workspan).dateTime}\r\n`;
+        if (match[user] === undefined) {
+          match[user] = [msgSsh];
+        } else {
+          match[user].push(msgSsh);
+        }
+      }
+      return null;
+    });
+  });
+  let message = [];
+  Object.keys(match).forEach(key => {
+    message.push(
+      `Empleado ${key} asociado con:\r\n${match[key].map(m => `${m}`)}`
+    );
+  });
+  if (error) {
+    alert = `No puede deshabilitar los siguientes empleados porque se encuentran asignados a uno o varios horarios activos:\r\n${message.map(
+      m => `${m}`
+    )}`;
+  } else {
+    alert = `Estado de usuario(s) ha sido cambiado exitosamente`;
   }
   return { alert, error };
 };

--- a/src/assets/helperFunctions/validationEmployee.js
+++ b/src/assets/helperFunctions/validationEmployee.js
@@ -1,3 +1,5 @@
+import { dbDateTimeToView } from "./index.js";
+
 const initEmployeeErrors = {
   firstnameerror: "",
   lastnameerror: "",
@@ -46,4 +48,44 @@ export const employeeValidation = emp => {
     employee = Object.assign({}, { ...employee, ...errors });
   }
   return { isError, employee };
+};
+
+// Delete validation
+export const notDeletable = (allServiceshifts, selected) => {
+  let match = {};
+  let error = false;
+  let alert = "";
+  selected.forEach(user => {
+    allServiceshifts.map(serviceshift => {
+      let empMatch = serviceshift.employees.find(emp => emp.user === user);
+      if (empMatch !== undefined) {
+        error = true;
+        let msgSsh = `Horario de sede ${
+          serviceshift.branch.branch
+        } con inicio el ${
+          dbDateTimeToView(serviceshift.begindate).dateTime
+        } y fin el ${dbDateTimeToView(serviceshift.workspan).dateTime}\r\n`;
+        if (match[user] === undefined) {
+          match[user] = [msgSsh];
+        } else {
+          match[user].push(msgSsh);
+        }
+      }
+      return null;
+    });
+  });
+  let message = [];
+  Object.keys(match).forEach(key => {
+    message.push(
+      `Empleado ${key} asociado con:\r\n${match[key].map(m => `${m}`)}`
+    );
+  });
+  if (error) {
+    alert = `No puede eliminar los siguientes empleados porque se encuentran asignados a uno o varios horarios:\r\n${message.map(
+      m => `${m}`
+    )}`;
+  } else {
+    alert = `Empleados(s) eliminado(s) correctamente`;
+  }
+  return { alert, error };
 };

--- a/src/assets/helperFunctions/validationServiceshift.js
+++ b/src/assets/helperFunctions/validationServiceshift.js
@@ -13,7 +13,7 @@ const lengthAttribute = object => {
   let isError = false;
   let errors = {};
   for (let attr in object) {
-    if (!attr.includes("error") && attr !== "id") {
+    if (!attr.includes("error") && attr !== "id" && attr !== "active") {
       if (
         (attr === "begindate" || attr === "workspan") &&
         object[attr].length === 0

--- a/src/assets/helperFunctions/validationServiceshift.js
+++ b/src/assets/helperFunctions/validationServiceshift.js
@@ -1,5 +1,6 @@
-import { modalDateTimeToLocalTime } from "./index.js";
+import { modalDateTimeToLocalTime, dbDateTimeToView } from "./index.js";
 
+// Helpers
 const initServiceshiftErrors = {
   begindateerror: "",
   workspanerror: "",
@@ -7,6 +8,7 @@ const initServiceshiftErrors = {
   branchIderror: ""
 };
 
+// Create and Update validation
 const lengthAttribute = object => {
   let isError = false;
   let errors = {};
@@ -37,10 +39,10 @@ const dateCoherence = object => {
   let { begindate, workspan } = object;
   begindate = modalDateTimeToLocalTime(begindate).format.db;
   workspan = modalDateTimeToLocalTime(workspan).format.db;
-  if (begindate >= workspan)
-   {
+  if (begindate >= workspan) {
     isError = true;
-    errors[`begindateerror`] = "La fecha de inicio debe de ser anterior a la fecha de fin";
+    errors[`begindateerror`] =
+      "La fecha de inicio debe de ser anterior a la fecha de fin";
   }
   return { isError, errors };
 };
@@ -62,4 +64,31 @@ export const serviceShiftValidation = ssh => {
     serviceShift = Object.assign({}, { ...serviceShift, ...errors });
   }
   return { isError, serviceshift: serviceShift };
+};
+
+// Delete validation
+export const notDeletable = (allServiceshifts, selected) => {
+  let message = [];
+  let error = false;
+  let alert = "";
+  selected.forEach(id => {
+    const match = allServiceshifts.find(serviceshift => serviceshift.id === id);
+    if (match.employees.length > 0) {
+      error = true;
+      message.push(
+        `Horario con sede en ${match.branch.branch}, inicio: ${
+          dbDateTimeToView(match.begindate).dateTime
+        }, fin: ${
+          dbDateTimeToView(match.workspan).dateTime}`
+      );
+    }
+  });
+  if (error) {
+    alert = `No puede eliminar los horarios de las siguientes sedes porque se encuentran asignados a uno o varios empleados:\r\n ${message.map(
+      m => `${m}\r\n`
+    )}`;
+  } else {
+    alert = `Horarios(s) eliminado(s) correctamente`;
+  }
+  return { alert, error };
 };

--- a/src/assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx
+++ b/src/assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx
@@ -34,7 +34,7 @@ const javascriptStyles = {
   ...tooltipsStyle,
   ...popoverStyles,
   overflow: {
-    width: "207px",
+    width: "300px",
     height: "240px",
     overflow: "auto"
   }

--- a/src/components/BoxForTime/BoxForTime.jsx
+++ b/src/components/BoxForTime/BoxForTime.jsx
@@ -27,7 +27,6 @@ class BoxForTime extends Component {
         this.setState({workspan});
     }
   render() {
-      console.log("workspan", this.state.workspan);
     return (
       <div>
         <div>

--- a/src/components/Modal/branch/Add.jsx
+++ b/src/components/Modal/branch/Add.jsx
@@ -15,11 +15,11 @@ import GridContainer from "components/Grid/GridContainer.jsx";
 import GridItem from "components/Grid/GridItem.jsx";
 import Button from "components/CustomButtons/Button.jsx";
 import CustomInput from "../../CustomInput/CustomInput.jsx";
-import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
+// import FormControl from "@material-ui/core/FormControl";
+// import FormHelperText from "@material-ui/core/FormHelperText";
 import javascriptStyles from "assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx";
 //Customized components
-import ActiveSelector from "../../Selector/ActiveSelector";
+// import ActiveSelector from "../../Selector/ActiveSelector";
 // queries and mutations with react-apollo
 import { Mutation } from "react-apollo";
 import { NEW_BRANCH } from "../../../mutations/branch";
@@ -111,7 +111,8 @@ class BranchModal extends React.Component {
           longitude: branch.longitude,
           contact: branch.contact,
           phone: branch.phone,
-          active: branch.active
+          // active: branch.active
+          active: true
         }
       });
       alert(`Sede ${branch.branch} ha sido agregada`);
@@ -229,7 +230,7 @@ class BranchModal extends React.Component {
                         onChange={this.handleChangeBranch}
                         inputProps={{ errorcomment: branch.phoneerror }}
                       />
-                      <FormControl fullWidth style={{ paddingTop: "10px" }}>
+                      {/* <FormControl fullWidth style={{ paddingTop: "10px" }}>
                         <ActiveSelector
                           active={branch.active}
                           onChange={this.handleChangeBranch}
@@ -241,7 +242,7 @@ class BranchModal extends React.Component {
                         >
                           {branch.activeerror ? branch.activeerror : null}
                         </FormHelperText>
-                      </FormControl>
+                      </FormControl> */}
                     </form>
                   </DialogContent>
                   <DialogActions className={classes.modalFooter}>

--- a/src/components/Modal/branch/Update.jsx
+++ b/src/components/Modal/branch/Update.jsx
@@ -15,11 +15,11 @@ import GridContainer from "components/Grid/GridContainer.jsx";
 import GridItem from "components/Grid/GridItem.jsx";
 import Button from "components/CustomButtons/Button.jsx";
 import CustomInput from "../../CustomInput/CustomInput.jsx";
-import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
+// import FormControl from "@material-ui/core/FormControl";
+// import FormHelperText from "@material-ui/core/FormHelperText";
 import javascriptStyles from "assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx";
 //Customized components
-import ActiveSelector from "../../Selector/ActiveSelector";
+// import ActiveSelector from "../../Selector/ActiveSelector";
 // queries and mutations with react-apollo
 import { Mutation } from "react-apollo";
 import { UPDATE_BRANCH } from "../../../mutations/branch";
@@ -27,7 +27,6 @@ import { UPDATE_BRANCH } from "../../../mutations/branch";
 import { withRouter } from "react-router-dom";
 // Helper functions
 import { branchValidation } from "assets/helperFunctions/validationBranch.js";
-
 
 function Transition(props) {
   return <Slide direction="down" {...props} />;
@@ -95,12 +94,15 @@ class UpdateModal extends React.Component {
     return (
       <div>
         <Tooltip title="Editar">
-          <IconButton
-            aria-label="Editar"
-            onClick={() => this.handleClickOpen("classicModal")}
-          >
-            <i className={"material-icons"}>edit</i>
-          </IconButton>
+          <div>
+            <IconButton
+              aria-label="Editar"
+              onClick={() => this.handleClickOpen("classicModal")}
+              disabled={!this.props.branch.active}
+            >
+              <i className={"material-icons"}>edit</i>
+            </IconButton>
+          </div>
         </Tooltip>
         <GridContainer>
           <GridItem xs={12} sm={12} md={6}>
@@ -191,7 +193,7 @@ class UpdateModal extends React.Component {
                         onChange={this.handleChangeBranch}
                         inputProps={{ errorcomment: branch.phoneerror }}
                       />
-                      <FormControl fullWidth style={{ paddingTop: "10px" }}>
+                      {/* <FormControl fullWidth style={{ paddingTop: "10px" }}>
                         <ActiveSelector
                           active={branch.active}
                           onChange={this.handleChangeBranch}
@@ -203,7 +205,7 @@ class UpdateModal extends React.Component {
                         >
                           {branch.activeerror ? branch.activeerror : null}
                         </FormHelperText>
-                      </FormControl>
+                      </FormControl> */}
                     </form>
                   </DialogContent>
                   <DialogActions className={classes.modalFooter}>

--- a/src/components/Modal/employee/Add.jsx
+++ b/src/components/Modal/employee/Add.jsx
@@ -15,11 +15,11 @@ import GridContainer from "components/Grid/GridContainer.jsx";
 import GridItem from "components/Grid/GridItem.jsx";
 import Button from "components/CustomButtons/Button.jsx";
 import CustomInput from "../../CustomInput/CustomInput.jsx";
-import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
+// import FormControl from "@material-ui/core/FormControl";
+// import FormHelperText from "@material-ui/core/FormHelperText";
 import javascriptStyles from "assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx";
 //Customized components
-import ActiveSelector from "../../Selector/ActiveSelector";
+// import ActiveSelector from "../../Selector/ActiveSelector";
 // GraphQL
 import { Mutation } from "react-apollo";
 import { NEW_EMPLOYEE } from "../../../mutations/employee.js";
@@ -120,7 +120,8 @@ class EmployeeModal extends React.Component {
           password: employee.password,
           dni: employee.dni,
           phone: employee.phone,
-          active: employee.active
+          active: true
+          // active: employee.active
         }
       });
       alert(`${employee.user} ha sido agregado`);
@@ -241,7 +242,7 @@ class EmployeeModal extends React.Component {
                         onChange={this.handleChangeEmployee}
                         inputProps={{ errorcomment: employee.dnierror }}
                       />
-                      <FormControl fullWidth style={{ paddingTop: "10px" }}>
+                      {/* <FormControl fullWidth style={{ paddingTop: "10px" }}>
                         <ActiveSelector
                           active={employee.active}
                           onChange={this.handleChangeEmployee}
@@ -254,7 +255,7 @@ class EmployeeModal extends React.Component {
                         >
                           {employee.activeerror ? employee.activeerror : null}
                         </FormHelperText>
-                      </FormControl>
+                      </FormControl> */}
                     </form>
                   </DialogContent>
                   <DialogActions className={classes.modalFooter}>

--- a/src/components/Modal/employee/Update.jsx
+++ b/src/components/Modal/employee/Update.jsx
@@ -15,11 +15,11 @@ import GridContainer from "components/Grid/GridContainer.jsx";
 import GridItem from "components/Grid/GridItem.jsx";
 import Button from "components/CustomButtons/Button.jsx";
 import CustomInput from "../../CustomInput/CustomInput.jsx";
-import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
+// import FormControl from "@material-ui/core/FormControl";
+// import FormHelperText from "@material-ui/core/FormHelperText";
 import javascriptStyles from "assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx";
 //Customized components
-import ActiveSelector from "../../Selector/ActiveSelector";
+// import ActiveSelector from "../../Selector/ActiveSelector";
 //GraphQL
 import { Mutation } from "react-apollo";
 import { UPDATE_EMPLOYEE } from "../../../mutations/employee.js";
@@ -100,12 +100,15 @@ class UpdateModal extends React.Component {
     return (
       <div align="left">
         <Tooltip title="Editar">
-          <IconButton
-            aria-label="Editar"
-            onClick={() => this.handleClickOpen("classicModal")}
-          >
-            <i className={"material-icons"}>edit</i>
-          </IconButton>
+          <div>
+            <IconButton
+              aria-label="Editar"
+              onClick={() => this.handleClickOpen("classicModal")}
+              disabled={!this.props.employee.active}
+            >
+              <i className={"material-icons"}>edit</i>
+            </IconButton>
+          </div>
         </Tooltip>
         <GridContainer>
           <GridItem xs={12} sm={12} md={6}>
@@ -197,7 +200,7 @@ class UpdateModal extends React.Component {
                         onChange={this.handleChangeEmployee}
                         inputProps={{ errorcomment: employee.dnierror }}
                       />
-                      <FormControl fullWidth style={{ paddingTop: "10px" }}>
+                      {/* <FormControl fullWidth style={{ paddingTop: "10px" }}>
                         <ActiveSelector
                           active={employee.active}
                           onChange={this.handleChangeEmployee}
@@ -209,7 +212,7 @@ class UpdateModal extends React.Component {
                         >
                           {employee.activeerror ? employee.activeerror : null}
                         </FormHelperText>
-                      </FormControl>
+                      </FormControl> */}
                     </form>
                   </DialogContent>
                   <DialogActions className={classes.modalFooter}>

--- a/src/components/Modal/serviceShift/Add.jsx
+++ b/src/components/Modal/serviceShift/Add.jsx
@@ -21,7 +21,7 @@ import FormHelperText from "@material-ui/core/FormHelperText";
 import javascriptStyles from "assets/jss/material-kit-react/views/componentsSections/javascriptStyles.jsx";
 //Customized components
 import BranchSelector from "../../Selector/BranchSelector";
-import ActiveSelector from "../../Selector/ActiveSelector";
+// import ActiveSelector from "../../Selector/ActiveSelector";
 // queries and mutations with react-apollo
 import { Query, Mutation } from "react-apollo";
 import { GET_BRANCHES } from "../../../queries/branch";
@@ -148,7 +148,7 @@ class Modal extends React.Component {
     let widthTmpFix = "lorem";
     widthTmpFix = widthTmpFix.repeat(8);
     let serviceShift = this.state.serviceShift;
-    let { active, branchId } = this.state.serviceShift;
+    let { /*active,*/ branchId } = this.state.serviceShift;
     return (
       <div>
         <Tooltip title="Agregar empleado">
@@ -273,7 +273,7 @@ class Modal extends React.Component {
                             : null}
                         </FormHelperText>
                       </FormControl>
-                      <br />
+                      {/* <br />
                       <br />
                       <InputLabel className={classes.label}>Estado</InputLabel>
                       <br />
@@ -291,7 +291,7 @@ class Modal extends React.Component {
                             ? serviceShift.activeerror
                             : null}
                         </FormHelperText>
-                      </FormControl>
+                      </FormControl> */}
                     </form>
                   </DialogContent>
                   <DialogActions className={classes.modalFooter}>

--- a/src/components/Modal/serviceShift/AddEmployee.jsx
+++ b/src/components/Modal/serviceShift/AddEmployee.jsx
@@ -21,6 +21,7 @@ import AddRmvEmployees from "components/CustomBox/AddRmvEmployees.jsx";
 import { withRouter } from "react-router-dom";
 // Helper functions
 import { getEmployeeName } from "assets/helperFunctions/index.js";
+import { employeesInServiceshifts } from "assets/helperFunctions/index.js";
 
 function Transition(props) {
   return <Slide direction="down" {...props} />;
@@ -42,6 +43,7 @@ class AddEmployee extends React.Component {
     );
     this.handleEmployeeToDelete = this.handleEmployeeToDelete.bind(this);
     this.handleSave = this.handleSave.bind(this);
+    this.filterDisabledEmployees = this.filterDisabledEmployees.bind(this);
   }
 
   handleClickOpen(modal) {
@@ -82,17 +84,37 @@ class AddEmployee extends React.Component {
     employeeToDelete = employeeToDelete[0];
     this.setState({ employeeToDelete });
   }
+
+  filterDisabledEmployees(employees) {
+    let filteredEmployees = [];
+    let employeesLinked = [];
+
+    let tmp = employeesInServiceshifts([this.state.serviceShift]);
+    tmp.map(emp => employeesLinked.push(emp.user));
+
+    filteredEmployees = employees.filter(
+      employee =>
+        employee.active === true ||
+        (employee.active === false &&
+          employeesLinked.indexOf(employee.user) !== -1)
+    );
+    return filteredEmployees;
+  }
+
   render() {
-    const { classes } = this.props;
+    const { classes, serviceShift } = this.props;
     return (
       <div>
         <Tooltip title="Agregar Empleado">
-          <IconButton
-            aria-label="Agregar Empleado"
-            onClick={() => this.handleClickOpen("classicModal")}
-          >
-            <i className={"material-icons"}>group_add</i>
-          </IconButton>
+          <div>
+            <IconButton
+              aria-label="Agregar Empleado"
+              onClick={() => this.handleClickOpen("classicModal")}
+              // disabled={!serviceShift.active}
+            >
+              <i className={"material-icons"}>group_add</i>
+            </IconButton>
+          </div>
         </Tooltip>
         <GridContainer>
           <GridItem xs={12} sm={12} md={6}>
@@ -136,7 +158,9 @@ class AddEmployee extends React.Component {
                   >
                     <div className={classes.overflow}>
                       <AddRmvEmployees
-                        employees={this.props.employees}
+                        employees={this.filterDisabledEmployees(
+                          this.props.employees
+                        )}
                         handleSave={this.handleSave}
                         handleDelete={this.updateEmployeeInServiceShift}
                         serviceShift={this.state.serviceShift}

--- a/src/components/Modal/serviceShift/AddEmployee.jsx
+++ b/src/components/Modal/serviceShift/AddEmployee.jsx
@@ -21,7 +21,6 @@ import AddRmvEmployees from "components/CustomBox/AddRmvEmployees.jsx";
 import { withRouter } from "react-router-dom";
 // Helper functions
 import { getEmployeeName } from "assets/helperFunctions/index.js";
-import { employeesInServiceshifts } from "assets/helperFunctions/index.js";
 
 function Transition(props) {
   return <Slide direction="down" {...props} />;
@@ -85,24 +84,22 @@ class AddEmployee extends React.Component {
     this.setState({ employeeToDelete });
   }
 
-  filterDisabledEmployees(employees) {
-    let filteredEmployees = [];
-    let employeesLinked = [];
-
-    let tmp = employeesInServiceshifts([this.state.serviceShift]);
-    tmp.map(emp => employeesLinked.push(emp.user));
-
-    filteredEmployees = employees.filter(
+  filterDisabledEmployees(employees, serviceShift) {
+    let assignedEmployees = [];
+    let allowedEmployees = [];
+    serviceShift.employees.map(emp => assignedEmployees.push(emp.user));
+    allowedEmployees = employees.filter(
       employee =>
         employee.active === true ||
         (employee.active === false &&
-          employeesLinked.indexOf(employee.user) !== -1)
+          assignedEmployees.indexOf(employee.user) !== -1)
     );
-    return filteredEmployees;
+    return allowedEmployees;
   }
 
   render() {
     const { classes, serviceShift } = this.props;
+    const filler = "lorem".repeat(8);
     return (
       <div>
         <Tooltip title="Agregar Empleado">
@@ -110,7 +107,7 @@ class AddEmployee extends React.Component {
             <IconButton
               aria-label="Agregar Empleado"
               onClick={() => this.handleClickOpen("classicModal")}
-              // disabled={!serviceShift.active}
+              disabled={!serviceShift.active}
             >
               <i className={"material-icons"}>group_add</i>
             </IconButton>
@@ -134,6 +131,7 @@ class AddEmployee extends React.Component {
                   aria-labelledby="classic-modal-slide-title"
                   aria-describedby="classic-modal-slide-description"
                 >
+                  <span style={{ opacity: "0" }}>{filler}</span>
                   <DialogTitle
                     id="classic-modal-slide-title"
                     disableTypography
@@ -159,7 +157,8 @@ class AddEmployee extends React.Component {
                     <div className={classes.overflow}>
                       <AddRmvEmployees
                         employees={this.filterDisabledEmployees(
-                          this.props.employees
+                          this.props.employees,
+                          this.props.serviceShift
                         )}
                         handleSave={this.handleSave}
                         handleDelete={this.updateEmployeeInServiceShift}

--- a/src/components/Modal/serviceShift/Update.jsx
+++ b/src/components/Modal/serviceShift/Update.jsx
@@ -21,7 +21,7 @@ import FormControl from "@material-ui/core/FormControl";
 import InputLabel from "@material-ui/core/InputLabel";
 //Customized components
 import BranchSelector from "../../Selector/BranchSelector";
-import ActiveSelector from "../../Selector/ActiveSelector";
+// import ActiveSelector from "../../Selector/ActiveSelector";
 // queries and mutations with react-apollo
 import { Mutation, Query } from "react-apollo";
 import { GET_BRANCHES } from "../../../queries/branch";
@@ -125,7 +125,7 @@ class UpdateModal extends React.Component {
 
   render() {
     const { classes } = this.props;
-    let { begindate, workspan, active, branch } = this.state.serviceshift;
+    let { begindate, workspan, /*active,*/ branch } = this.state.serviceshift;
     begindate = new Date(begindate);
     workspan = new Date(workspan);
     let branchId = branch.id;
@@ -139,7 +139,7 @@ class UpdateModal extends React.Component {
             <IconButton
               aria-label="Editar"
               onClick={() => this.handleClickOpen("classicModal")}
-              // disabled={!serviceshift.active}
+              disabled={!this.props.serviceshift.active}
             >
               <i className={"material-icons"}>edit</i>
             </IconButton>
@@ -248,7 +248,7 @@ class UpdateModal extends React.Component {
                           }}
                         </Query>
                       </FormControl>
-                      <br />
+                      {/* <br />
                       <br />
                       <InputLabel className={classes.label}>Estado</InputLabel>
                       <br />
@@ -258,7 +258,7 @@ class UpdateModal extends React.Component {
                           active={active}
                           modal="update"
                         />
-                      </FormControl>
+                      </FormControl> */}
                     </form>
                   </DialogContent>
                   <DialogActions className={classes.modalFooter}>

--- a/src/components/Modal/serviceShift/Update.jsx
+++ b/src/components/Modal/serviceShift/Update.jsx
@@ -135,12 +135,15 @@ class UpdateModal extends React.Component {
     return (
       <div>
         <Tooltip title="Editar">
-          <IconButton
-            aria-label="Editar"
-            onClick={() => this.handleClickOpen("classicModal")}
-          >
-            <i className={"material-icons"}>edit</i>
-          </IconButton>
+          <div>
+            <IconButton
+              aria-label="Editar"
+              onClick={() => this.handleClickOpen("classicModal")}
+              // disabled={!serviceshift.active}
+            >
+              <i className={"material-icons"}>edit</i>
+            </IconButton>
+          </div>
         </Tooltip>
         <GridContainer>
           <GridItem xs={12} sm={12} md={6}>

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ import ApolloClient from "apollo-boost";
 import { ApolloProvider } from "react-apollo";
 
 const client = new ApolloClient({
-  // uri: "https://vp-project.herokuapp.com/graphql"
-  uri: "http://localhost:4000/graphql"
+  uri: "https://vp-project.herokuapp.com/graphql"
+  // uri: "http://localhost:4000/graphql"
 });
 
 var hist = createBrowserHistory();

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ import ApolloClient from "apollo-boost";
 import { ApolloProvider } from "react-apollo";
 
 const client = new ApolloClient({
-  uri: "https://vp-project.herokuapp.com/graphql"
-  // uri: "http://localhost:4000/graphql"
+  // uri: "https://vp-project.herokuapp.com/graphql"
+  uri: "http://localhost:4000/graphql"
 });
 
 var hist = createBrowserHistory();

--- a/src/mutations/branch.js
+++ b/src/mutations/branch.js
@@ -78,3 +78,12 @@ export const DELETE_BRANCH = gql`
     }
   }
 `;
+
+export const DISABLE_BRANCH = gql`
+  mutation disableBranch($id: ID!) {
+    disableBranch(id: $id) {
+      id
+      active
+    }
+  }
+`;

--- a/src/mutations/serviceShift.js
+++ b/src/mutations/serviceShift.js
@@ -121,3 +121,12 @@ mutation updateServiceShift(
   }
 }
 `;
+
+export const DISABLE_SERVICESHIFT = gql`
+mutation disableServiceshift($id: ID!) {
+  disableServiceshift(id: $id) {
+    id
+    active
+  }
+}
+`;

--- a/src/views/AdminPage/Sections/Branches/EnhancedTable.jsx
+++ b/src/views/AdminPage/Sections/Branches/EnhancedTable.jsx
@@ -324,8 +324,8 @@ class EnhancedTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      order: "asc",
-      orderBy: "user",
+      order: "desc",
+      orderBy: "active",
       selected: [],
       data: [],
       page: 0,

--- a/src/views/AdminPage/Sections/Branches/EnhancedTable.jsx
+++ b/src/views/AdminPage/Sections/Branches/EnhancedTable.jsx
@@ -26,7 +26,8 @@ import { GET_BRANCHES } from "../../../../queries/branch";
 import Add from "../../../../components/Modal/branch/Add";
 import Update from "../../../../components/Modal/branch/Update";
 import Display from "../../../../components/Modal/branch/Display";
-import { branchesInServiceshifts } from "assets/helperFunctions/index.js";
+// Helper functions
+import { notDeletable } from "assets/helperFunctions/validationBranch.js";
 
 function desc(a, b, orderBy) {
   if (b[orderBy] < a[orderBy]) {
@@ -168,33 +169,12 @@ const updateCacheDelete = (cache, { data: { deleteBranch } }) => {
 
 class EnhancedTableToolbar extends React.Component {
   deleteOnClick(deleteBranch, selected, history) {
-    let { serviceshifts } = this.props;
-    let branchesLinked = branchesInServiceshifts(serviceshifts);
-    let branchesRestricted = [];
-    selected.map(branch => {
-      branchesLinked.map(brn => {
-        if (brn.id === branch) {
-          branchesRestricted.push({ id: brn.id, branch: brn.branch });
-        }
-        return null;
-      });
-      return null;
-    });
-    if (branchesRestricted.length === 0) {
-      selected.map(id =>
-        deleteBranch({
-          variables: { id }
-        })
-      );
-      alert(`Sede(s) eliminada(s)`);
+    const validationDelete = notDeletable(this.props.serviceshifts, selected);
+    if (!validationDelete.error) {
+      selected.map(id => deleteBranch({ variables: { id } }));
       this.props.resetValues();
-    } else {
-      alert(
-        `No puede eliminar las siguientes sedes porque se encuentran asignadas a uno o varios horarios:\r\n ${branchesRestricted.map(
-          brn => `${brn.branch}\r\n`
-        )}`
-      );
     }
+    alert(validationDelete.alert);
   }
   render() {
     const { numSelected, classes, selected, history } = this.props;

--- a/src/views/AdminPage/Sections/ServiceShifts/EnhancedTable.jsx
+++ b/src/views/AdminPage/Sections/ServiceShifts/EnhancedTable.jsx
@@ -339,8 +339,8 @@ class EnhancedTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      order: "asc",
-      orderBy: "branch",
+      order: "desc",
+      orderBy: "active",
       selected: [],
       data: [],
       page: 0,

--- a/src/views/AdminPage/Sections/ServiceShifts/EnhancedTable.jsx
+++ b/src/views/AdminPage/Sections/ServiceShifts/EnhancedTable.jsx
@@ -30,7 +30,7 @@ import Display from "../../../../components/Modal/serviceShift/Display";
 import ModalAddEmployee from "../../../../components/Modal/serviceShift/AddEmployee.jsx";
 // Helper functions
 import { dbDateTimeToView } from "assets/helperFunctions/index.js";
-import { employeesInServiceshifts } from "assets/helperFunctions/index.js";
+import { notDeletable } from "assets/helperFunctions/validationServiceshift.js";
 
 function desc(a, b, orderBy) {
   if (orderBy === "branch") {
@@ -181,41 +181,15 @@ const updateCacheDelete = (cache, { data: { deleteServiceShift } }) => {
 
 class EnhancedTableToolbar extends React.Component {
   deleteOnClick(deleteServiceShift, selected, history) {
-    let allServiceshifts = this.props.allServiceshifts;
-    let serviceshiftsToDelete = [];
-    let serviceshiftsLinked = [];
-    selected.map(id => {
-      allServiceshifts.map(serviceshift => {
-        if (serviceshift.id === id) {
-          serviceshiftsToDelete.push({
-            begindate: serviceshift.begindate,
-            branch: serviceshift.branch.branch,
-            employees: serviceshift.employees
-          });
-        }
-      });
-    });
-    serviceshiftsToDelete.map(n => {
-      if (n.employees.length !== 0) {
-        serviceshiftsLinked.push(n)
-    }});
-    if (serviceshiftsLinked.length === 0) {
-      selected.map(id => {
-        deleteServiceShift({
-          variables: { id }
-        });
-        return null;
-      });
-      alert(`Horario(s) eliminado(s)`);
+    const validationDelete = notDeletable(
+      this.props.allServiceshifts,
+      selected
+    );
+    if (!validationDelete.error) {
+      selected.map(id => deleteServiceShift({ variables: { id } }));
       this.props.resetValues();
-    } else {
-      alert(
-        `No puede eliminar los horarios de las siguientes sedes porque se encuentran asignados a uno o varios empleados:\r\n ${serviceshiftsLinked.map(
-          ssh => `En sede" ${ssh.branch}, inicio: ${dbDateTimeToView(ssh.begindate).dateTime}\r\n`
-        )}`
-      );
     }
-
+    alert(validationDelete.alert);
   }
   render() {
     const { numSelected, classes, selected, history } = this.props;


### PR DESCRIPTION
# Expected Behavior

DISABLING REGISTERS:
Disable action should be restricted to change the status of objects that are not going to be part of the workflow anymore but they should remain as historic data, then:

Serviceshift:
- [x] It should be the first object to disable
- [x] There is no previous requirement to disable a serviceshift (suggestion: check returned field in parking data, if false, then do not alllow disable execution)
- [x] Disabled serviceshifts (active === false) should have edit and add/remove employee buttons in disable state

Employee:
- [x] Active serviceshifts to which it belongs should be inactive
- [x] Only active employees are going to be shown in link/unlink employees action in serviceshift view
- [x] Disabled employees should have edit button in disable state

Branch:
- [x] Active serviceshifts to which it belongs should be inactive
- [x] Disabled branches should have edit button in disable state 


DELETING REGISTERS
- [x] Optimized functions for Create and Update actions in branch, serviceshift and employee views

EDIT AND CREATE ACTIONS
- [x] Modals responsible of Create and Update actions should not handle any operation on attribute "action" anymore.
- [x] Employees, branches and serviceshifts should be created with active === true by default
- [x] Employees, branches and serviceshifts should only handle any change in attribute "active" through the select mechanism in the enhanced table

OTHERS
- [x] Employees, branches and serviceshifts tables should be ordered by default by active attribute
