### PR TITLE
fixing login warning pop up

### DIFF
--- a/src/views/AdminPage/Sections/Login/Login.jsx
+++ b/src/views/AdminPage/Sections/Login/Login.jsx
@@ -54,8 +54,7 @@ class Login extends React.Component {
       errors.forEach(({ path, message }) => {
         err[`${path}Error`] = message;
       });
-      // this.setState({ ["errors"]: err });
-      this.state["errors"] = err;
+      this.setState({ errors: err });
     }
   };
 


### PR DESCRIPTION
Login warnings did not pop up when introducing bad credentials but after having typed new values. Problem was fixed by omitting:

this.setState({ ["errors"]: err });
this.state["errors"] = err;

and setting:

this.setState({ errors: err });
